### PR TITLE
Adjust radius to read height at each tile instead of only the corners

### DIFF
--- a/src/main/java/com/goadinghelper/GoadingRadiusOverlay.java
+++ b/src/main/java/com/goadinghelper/GoadingRadiusOverlay.java
@@ -92,13 +92,30 @@ public class GoadingRadiusOverlay extends OverlayPanel
 
 		// Corner 1: (startX, startY)
 		moveTo(path, startX, startY, z);
+
 		// Corner 2: (startX + diameter, startY)
-		lineTo(path, startX + diameter, startY, z);
+		for (int i = 1; i <= diameter; i++)
+		{
+			lineTo(path, startX + i, startY, z);
+		}
+
 		// Corner 3: (startX + diameter, startY + diameter)
-		lineTo(path, startX + diameter, startY + diameter, z);
+		for (int i = 1; i <= diameter; i++)
+		{
+			lineTo(path, startX + diameter, startY + i, z);
+		}
+
 		// Corner 4: (startX, startY + diameter)
-		lineTo(path, startX, startY + diameter, z);
+		for (int i = 1; i <= diameter; i++)
+		{
+			lineTo(path, startX + diameter - i, startY + diameter, z);
+		}
+
 		// Close the square back to Corner 1
+		for (int i = 1; i <= diameter-1; i++)
+		{
+			lineTo(path, startX, startY + diameter - i, z);
+		}
 		path.closePath();
 
 		return path;


### PR DESCRIPTION
Adjusts the radius overlay to be more readable in areas with large height differences between tiles.

Before:
![Screenshot 2024-11-09 222342](https://github.com/user-attachments/assets/2b51720a-b46a-491c-a49b-b0762237e3a5)

After:
![Screenshot 2024-11-09 221314](https://github.com/user-attachments/assets/a7811218-2360-42c1-a2f7-c71a8f13199a)
